### PR TITLE
Minor typo fixes for the template

### DIFF
--- a/_files/template.md
+++ b/_files/template.md
@@ -18,17 +18,17 @@ Header Section: include the following information.
 
 - **Description:** A template on how to write a notebook tutorial on sciserver.
 - **Level:** Beginner | Intermediate | Advanced.
-- **Data:** Descirbe what data, if any will be use. If None, write: NA
-- **Requirements:** Describe what is needed to run the notebooks. For example: "Run in the (heasof) conda environment on Sciserver". Or "python packages: [`heasoftpy`, `astropy`, `numpy`]".
+- **Data:** Describe what data, if any will be use. If None, write: NA
+- **Requirements:** Describe what is needed to run the notebooks. For example: "Run in the (heasoft) conda environment on Sciserver". Or "python packages: [`heasoftpy`, `astropy`, `numpy`]".
 - **Credit:** Who wrote the notebebook and when.
 - **Support:** How to get help.
-- **Last verified to run:** (00/00/000) When was this last tested.
+- **Last verified to run:** MM/DD/YYYY When was this last tested.
 
 <hr style="border: 2px solid #fadbac" />
 
 
 ## 1. Introduction
-Describe the content. It can contain 0plain text, bullets, and/or images as needed. 
+Describe the content. It can contain plain text, bullets, and/or images as needed. 
 Use `Markdown` when writing.
 
 The following are suggested subsections. Not all are needed:
@@ -37,7 +37,7 @@ The following are suggested subsections. Not all are needed:
 - Details about the requirements, and on running the notebook outside Sciserver. 
 - Type of outcome or end product.
 
-You may want to include the following section on how to run the notebook outise sciserver.
+You may want to include the following section on how to run the notebook outside sciserver.
 <div style='color: #333; background: #ffffdf; padding:20px; border: 4px solid #fadbac'>
 <b>Running On Sciserver:</b><br>
 When running this notebook inside Sciserver, make sure the HEASARC data drive is mounted when initializing the Sciserver compute container. <a href='https://heasarc.gsfc.nasa.gov/docs/sciserver/'>See details here</a>.
@@ -59,7 +59,7 @@ The following gives an example sections.
 import heasoftpy as hsp
 ```
 
-## 3.0 Define Input if needed
+## 3. Define Input if needed
 This section will include things like:
 - obsIDs
 - Plot settings


### PR DESCRIPTION
- several minor spelling mistakes
- be explicit about the date format
- change a section title number to match the other sections ('x.', not 'x.0')